### PR TITLE
Step14

### DIFF
--- a/src/main/java/com/hhplush/eCommerce/api/coupon/CouponController.java
+++ b/src/main/java/com/hhplush/eCommerce/api/coupon/CouponController.java
@@ -4,6 +4,7 @@ import static com.hhplush.eCommerce.common.exception.message.ExceptionMessage.IN
 
 import com.hhplush.eCommerce.api.coupon.dto.request.RequestIssueCouponDTO;
 import com.hhplush.eCommerce.api.coupon.dto.response.ResponseIssueCouponDTO;
+import com.hhplush.eCommerce.api.coupon.dto.response.ResponseIssueCouponDTOV2;
 import com.hhplush.eCommerce.business.coupon.CouponUseCase;
 import com.hhplush.eCommerce.common.exception.ErrorResponse;
 import com.hhplush.eCommerce.domain.coupon.UserCoupon;
@@ -78,4 +79,16 @@ public class CouponController {
                 .build());
     }
 
+
+    @PostMapping("/{couponId}/issued/V2")
+    public ResponseEntity<ResponseIssueCouponDTOV2> issueCouponV2(
+        @Schema(description = "쿠폰 ID", example = "1")
+        @PathVariable("couponId") @Min(value = 1, message = INVALID_ID) Long couponId,
+        @Valid @RequestBody RequestIssueCouponDTO requestIssueCouponDTO
+    ) {
+        couponUseCase.issueCouponRequest(couponId,
+            requestIssueCouponDTO.userId());
+        return
+            ResponseEntity.ok(ResponseIssueCouponDTOV2.builder().result("SUCCESS").build());
+    }
 }

--- a/src/main/java/com/hhplush/eCommerce/api/coupon/dto/response/ResponseIssueCouponDTOV2.java
+++ b/src/main/java/com/hhplush/eCommerce/api/coupon/dto/response/ResponseIssueCouponDTOV2.java
@@ -1,0 +1,10 @@
+package com.hhplush.eCommerce.api.coupon.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ResponseIssueCouponDTOV2(
+    String result
+) {
+
+}

--- a/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
+++ b/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
@@ -65,4 +65,10 @@ public class CouponUseCase {
         couponService.couponToQueue(couponId.toString(), userId.toString());
     }
 
+    @Scheduled(fixedDelay = 1) // 0.1초마다 실행
+    @Transactional
+    public void processCouponQueue() {
+        // 쿠폰 발급 대기열 처리
+        couponService.processCouponQueue();
+    }
 }

--- a/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
+++ b/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
@@ -65,8 +65,7 @@ public class CouponUseCase {
         couponService.couponToQueue(couponId.toString(), userId.toString());
     }
 
-    @Scheduled(fixedDelay = 1) // 0.1초마다 실행
-    @Transactional
+    @Scheduled(fixedDelay = 500) // 0.1초마다 실행
     public void processCouponQueue() {
         // 쿠폰 발급 대기열 처리
         couponService.processCouponQueue();

--- a/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
+++ b/src/main/java/com/hhplush/eCommerce/business/coupon/CouponUseCase.java
@@ -65,7 +65,7 @@ public class CouponUseCase {
         couponService.couponToQueue(couponId.toString(), userId.toString());
     }
 
-    @Scheduled(fixedDelay = 500) // 0.1초마다 실행
+    @Scheduled(fixedDelay = 100) // 0.1초마다 실행
     public void processCouponQueue() {
         // 쿠폰 발급 대기열 처리
         couponService.processCouponQueue();

--- a/src/main/java/com/hhplush/eCommerce/common/utils/RedisUtil.java
+++ b/src/main/java/com/hhplush/eCommerce/common/utils/RedisUtil.java
@@ -1,0 +1,22 @@
+package com.hhplush.eCommerce.common.utils;
+
+public class RedisUtil {
+
+    public static final String COUPON_KEY = "coupon:";
+    public static final String USER_KEY = "user:";
+    public static final String COUPON_QUEUE_KEY = "coupon:queue";
+    public static final String COUPON_ISSUED_KEY = "coupon:issued";
+    public static final int POLL_SIZE = 10;
+
+    public static String getCouponKey(String couponId) {
+        return COUPON_KEY + couponId;
+    }
+
+    public static String getUserKey(String userId) {
+        return USER_KEY + userId;
+    }
+
+    public static String getIssuedCouponKey(String couponId, String userId) {
+        return COUPON_KEY + couponId + ":" + USER_KEY + userId;
+    }
+}

--- a/src/main/java/com/hhplush/eCommerce/config/RedisConfiguration.java
+++ b/src/main/java/com/hhplush/eCommerce/config/RedisConfiguration.java
@@ -1,4 +1,4 @@
-package com.hhplush.eCommerce.infrastructure.redis;
+package com.hhplush.eCommerce.config;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -16,9 +16,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Slf4j
 @Configuration
@@ -26,9 +23,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfiguration {
 
     private static final String REDISSON_HOST_PREFIX = "redis://";
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean
@@ -51,20 +48,6 @@ public class RedisConfiguration {
             .cacheDefaults(redisCacheConfiguration)
             .build();
         return cacheManager;
-    }
-
-
-    @Bean
-    // 레디스 캐시를 직접 조작
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        template.setKeySerializer(new StringRedisSerializer());
-
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
-        return template;
     }
 
     @Bean

--- a/src/main/java/com/hhplush/eCommerce/config/SchedulerConfig.java
+++ b/src/main/java/com/hhplush/eCommerce/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.hhplush.eCommerce.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/com/hhplush/eCommerce/domain/IRedisRepository.java
+++ b/src/main/java/com/hhplush/eCommerce/domain/IRedisRepository.java
@@ -1,0 +1,24 @@
+package com.hhplush.eCommerce.domain;
+
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+
+public interface IRedisRepository {
+
+    // 키가 존재하는지 조회
+    boolean isExists(String key);
+
+    // Key에 대한 AtomicLong 객체 반환
+    RAtomicLong getAtomicLong(String key);
+
+
+    // ScoredSortedSet 값 추가
+    void addScoredSortedSet(String queueKey, String issuedCouponKey);
+
+    // ScoredSortedSet 값 조회
+    RScoredSortedSet<String> getScoredSortedSet(String queueKey);
+
+    // getMap
+    RMap<String, Boolean> getMap(String key);
+}

--- a/src/main/java/com/hhplush/eCommerce/domain/coupon/ICouponRepository.java
+++ b/src/main/java/com/hhplush/eCommerce/domain/coupon/ICouponRepository.java
@@ -22,6 +22,11 @@ public interface ICouponRepository {
     // 유저 쿠폰 발급
     void userCouponSave(UserCoupon userCoupon);
 
+
+    // 유저 쿠폰 발급 (리스트)
+    void userCouponSaveList(List<UserCoupon> userCouponsList);
+
+
     // 유저 쿠폰 조회
     Optional<UserCoupon> userCouponfindById(Long userCouponId);
 

--- a/src/main/java/com/hhplush/eCommerce/infrastructure/coupon/CouponRepository.java
+++ b/src/main/java/com/hhplush/eCommerce/infrastructure/coupon/CouponRepository.java
@@ -40,7 +40,6 @@ public class CouponRepository implements ICouponRepository {
         return couponQuantityJPARepository.findCouponQuantityByCouponId(couponId);
     }
 
-
     // 쿠폰 수량 저장
     @Override
     public void couponQuantitySave(CouponQuantity couponQuantity) {
@@ -51,6 +50,11 @@ public class CouponRepository implements ICouponRepository {
     @Override
     public void userCouponSave(UserCoupon userCoupon) {
         userCouponJPARepository.save(userCoupon);
+    }
+
+    @Override
+    public void userCouponSaveList(List<UserCoupon> userCouponsList) {
+        userCouponJPARepository.saveAll(userCouponsList);
     }
 
     // 유저 쿠폰 조회

--- a/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisRepository.java
@@ -1,0 +1,47 @@
+package com.hhplush.eCommerce.infrastructure.redis;
+
+import com.hhplush.eCommerce.domain.IRedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisRepository implements IRedisRepository {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public boolean isExists(String key) {
+        return redissonClient.getBucket(key).isExists();
+    }
+
+    @Override
+    public RAtomicLong getAtomicLong(String key) {
+        return redissonClient.getAtomicLong(key);
+    }
+
+    @Override
+    public void addScoredSortedSet(String queueKey, String issuedCouponKey) {
+        RScoredSortedSet<String> couponQueue = redissonClient.getScoredSortedSet(queueKey);
+        // 쿠폰 발급 대기열에 추가
+        log.info("쿠폰 발급 대기열 추가: key = {}", issuedCouponKey);
+        couponQueue.add(System.currentTimeMillis(), issuedCouponKey);
+    }
+
+    @Override
+    public RScoredSortedSet<String> getScoredSortedSet(String queueKey) {
+        return redissonClient.getScoredSortedSet(queueKey);
+    }
+
+    @Override
+    public RMap<String, Boolean> getMap(String key) {
+        return redissonClient.getMap(key);
+    }
+
+}

--- a/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisService.java
+++ b/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisService.java
@@ -1,0 +1,46 @@
+package com.hhplush.eCommerce.infrastructure.redis;
+
+import static com.hhplush.eCommerce.common.utils.RedisUtil.COUPON_ISSUED_KEY;
+
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class RedisService {
+
+    private final RedissonClient redissonClient;
+
+    public RedisService(RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
+    }
+
+    // 쿠폰 수량 저장
+    public void addCouponQuantity(String key, Long number) {
+        RAtomicLong atomicLong = redissonClient.getAtomicLong(key);
+        atomicLong.set(number);
+    }
+
+
+    // 쿠폰 수량 조회
+    public Long getCouponQuantity(String key) {
+        RAtomicLong atomicCoupon = redissonClient.getAtomicLong(key);
+        return atomicCoupon.get();
+    }
+
+    // 쿠폰 큐 조회
+    public RScoredSortedSet<String> getSetValue(String key) {
+        RScoredSortedSet<String> setValue = redissonClient.getScoredSortedSet(key);
+        return setValue;
+    }
+
+    // 쿠폰 발급 이력 조회
+    public Integer getCouponIssuedList(String key) {
+        RMap<String, Boolean> issuedUsers = redissonClient.getMap(COUPON_ISSUED_KEY);
+        return issuedUsers.size();
+    }
+}

--- a/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisService.java
+++ b/src/main/java/com/hhplush/eCommerce/infrastructure/redis/RedisService.java
@@ -43,4 +43,9 @@ public class RedisService {
         RMap<String, Boolean> issuedUsers = redissonClient.getMap(COUPON_ISSUED_KEY);
         return issuedUsers.size();
     }
+
+    // 레디스의 모든 키 삭제
+    public void deleteAllKeys() {
+        redissonClient.getKeys().flushall();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,11 +24,18 @@ spring:
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
-  redis:
-    host: localhost
-    port: 6379
+
+  data:
+    redis:
+      repositories:
+        enabled: false
+      host: localhost
+      port: 6379
   cache:
     type: redis
+  task:
+    scheduling:
+      enabled: true
 
 logging:
   level:
@@ -55,5 +62,14 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+  data:
+    redis:
+      repositories:
+        enabled: false
+      host: localhost
+      port: 6379
   cache:
     type: redis
+  task:
+    scheduling:
+      enabled: true

--- a/src/test/java/com/hhplush/eCommerce/TestcontainersConfiguration.java
+++ b/src/test/java/com/hhplush/eCommerce/TestcontainersConfiguration.java
@@ -1,18 +1,23 @@
 package com.hhplush.eCommerce;
 
+import groovy.util.logging.Slf4j;
 import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
+@Slf4j
 class TestcontainersConfiguration {
 
     public static final MySQLContainer<?> MYSQL_CONTAINER;
 
     // Redis 컨테이너
     public static final GenericContainer<?> REDIS_CONTAINER;
+    private static final Logger log = LoggerFactory.getLogger(TestcontainersConfiguration.class);
 
     static {
         MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -40,11 +45,13 @@ class TestcontainersConfiguration {
     @PreDestroy
     public void preDestroy() {
         if (MYSQL_CONTAINER.isRunning()) {
+            log.info("MySQL 컨테이너 종료");
             MYSQL_CONTAINER.stop();
         }
 
         // Redis 컨테이너 종료
         if (REDIS_CONTAINER.isRunning()) {
+            log.info("Redis 컨테이너 종료");
             REDIS_CONTAINER.stop();
         }
     }

--- a/src/test/java/com/hhplush/eCommerce/TestcontainersConfiguration.java
+++ b/src/test/java/com/hhplush/eCommerce/TestcontainersConfiguration.java
@@ -32,8 +32,9 @@ class TestcontainersConfiguration {
         REDIS_CONTAINER.start();
 
         // Spring Redis 프로퍼티 설정
-        System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
-        System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.data.redis.port",
+            REDIS_CONTAINER.getMappedPort(6379).toString());
     }
 
     @PreDestroy

--- a/src/test/java/com/hhplush/eCommerce/integration/business/coupon/CouponUseCaseTest.java
+++ b/src/test/java/com/hhplush/eCommerce/integration/business/coupon/CouponUseCaseTest.java
@@ -289,7 +289,7 @@ public class CouponUseCaseTest extends IntegrationTest {
             executorService.shutdown();
 
             // 스케쥴러 동작을 위한 슬립
-            Thread.sleep(1000);
+            Thread.sleep(5000);
 
             // then
             // 쿠폰 발급 확인
@@ -346,9 +346,10 @@ public class CouponUseCaseTest extends IntegrationTest {
 
             int couponsize = couponList.size();
             int usersize = userList.size();
-            for (int i = 0; i < 500; i++) {
-                Long couponId = random.nextLong(couponsize) + 1L;
-                Long userId = random.nextLong(usersize) + 1L;
+
+            for (int i = 0; i < 1500; i++) {
+                Long couponId = couponList.get(random.nextInt(couponsize)).getCouponId();
+                Long userId = userList.get(random.nextInt(usersize)).getUserId();
                 executorService.execute(() -> {
                     try {
                         couponUseCase.issueCouponRequest(couponId, userId);

--- a/src/test/java/com/hhplush/eCommerce/integration/business/coupon/CouponUseCaseTest.java
+++ b/src/test/java/com/hhplush/eCommerce/integration/business/coupon/CouponUseCaseTest.java
@@ -1,5 +1,8 @@
 package com.hhplush.eCommerce.integration.business.coupon;
 
+import static com.hhplush.eCommerce.common.utils.RedisUtil.COUPON_ISSUED_KEY;
+import static com.hhplush.eCommerce.common.utils.RedisUtil.COUPON_KEY;
+import static com.hhplush.eCommerce.common.utils.RedisUtil.COUPON_QUEUE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hhplush.eCommerce.domain.coupon.Coupon;
@@ -10,14 +13,20 @@ import com.hhplush.eCommerce.domain.user.User;
 import com.hhplush.eCommerce.integration.config.IntegrationTest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RScoredSortedSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CouponUseCaseTest extends IntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CouponUseCaseTest.class);
 
     @Nested
     @DisplayName("쿠폰 발급 동시성 제어 - 비관적 락")
@@ -127,7 +136,7 @@ public class CouponUseCaseTest extends IntegrationTest {
     }
 
     @Nested
-    @DisplayName("쿠폰 발급 동시성 제어 - Redis")
+    @DisplayName("쿠폰 발급 동시성 제어 - Redis 분산락")
     class IssueCouponConcurrencyWithRedis {
 
         @Test
@@ -231,6 +240,149 @@ public class CouponUseCaseTest extends IntegrationTest {
             List<UserCoupon> userCouponList = userCouponJPARepository.findAll();
             assertEquals(0L, cq.getQuantity());
             assertEquals(10, userCouponList.size());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("쿠폰 발급 동시성 제어 - Redis")
+    class IssueCouponConcurrencyWithRedisService {
+
+        @Test
+        void 동일한_유저가_쿠폰발급_동시에_여러건을_시도할때_1개만_발급한다() throws InterruptedException {
+            // given
+            User user = User.builder()
+                .userName("Test User")
+                .point(100L)
+                .build();
+            user = userJPARepository.save(user);
+
+            Coupon coupon = Coupon.builder()
+                .couponName("Test Coupon")
+                .discountAmount(1000L)
+                .couponState(CouponState.ISSUABLE)
+                .build();
+
+            coupon = couponJPARepository.save(coupon);
+
+            // 레디스 스토리지에 쿠폰 재고 10개 저장
+            redisService.addCouponQuantity("coupon:" + coupon.getCouponId().toString(), 10L);
+
+            // when
+            ExecutorService executorService = Executors.newFixedThreadPool(20);
+            CountDownLatch countDownLatch = new CountDownLatch(20);
+
+            for (int i = 0; i < 20; i++) {
+                Long couponId = coupon.getCouponId();
+                Long userId = user.getUserId();
+                executorService.execute(() -> {
+                    try {
+                        couponUseCase.issueCouponRequest(couponId, userId);
+                    } catch (Exception e) {
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+
+            countDownLatch.await();
+            executorService.shutdown();
+
+            // 스케쥴러 동작을 위한 슬립
+            Thread.sleep(1000);
+
+            // then
+            // 쿠폰 발급 확인
+            List<UserCoupon> userCoupon = userCouponJPARepository.findAll();
+            assertEquals(1, userCoupon.size());
+            // 큐 0건인지 확인
+            RScoredSortedSet<String> value = redisService.getSetValue(COUPON_QUEUE_KEY);
+            assertEquals(0, value.size());
+            // 쿠폰 재고 9개인지 확인
+            assertEquals(9,
+                redisService.getCouponQuantity(COUPON_KEY + coupon.getCouponId().toString()));
+            // 쿠폰 발급 이력 1건인지 확인
+            assertEquals(1, redisService.getCouponIssuedList(COUPON_ISSUED_KEY));
+        }
+
+        @Test
+        void 여러_유저가_쿠폰발급_요청하는_경우_갯수만큼만_발급한다() throws InterruptedException {
+            // given
+            List<User> userList = new ArrayList<>();
+            List<Coupon> couponList = new ArrayList<>();
+            for (int i = 1; i <= 200; i++) {
+                User user = User.builder()
+                    .userName("Test User" + i)
+                    .point(100L)
+                    .build();
+                userList.add(user);
+            }
+            userList = userJPARepository.saveAll(userList);
+
+            Coupon coupon = Coupon.builder()
+                .couponName("Test Coupon")
+                .discountAmount(1000L)
+                .couponState(CouponState.ISSUABLE)
+                .build();
+            coupon = couponJPARepository.save(coupon);
+
+            Coupon coupon2 = Coupon.builder()
+                .couponName("Test Coupon2")
+                .discountAmount(1000L)
+                .couponState(CouponState.ISSUABLE)
+                .build();
+            coupon2 = couponJPARepository.save(coupon2);
+
+            redisService.addCouponQuantity("coupon:" + coupon.getCouponId().toString(), 100L);
+            redisService.addCouponQuantity("coupon:" + coupon2.getCouponId().toString(), 100L);
+
+            couponList.add(coupon);
+            couponList.add(coupon2);
+
+            // when
+            Random random = new Random();
+            ExecutorService executorService = Executors.newFixedThreadPool(15);
+            CountDownLatch countDownLatch = new CountDownLatch(500);
+
+            int couponsize = couponList.size();
+            int usersize = userList.size();
+            for (int i = 0; i < 500; i++) {
+                Long couponId = random.nextLong(couponsize) + 1L;
+                Long userId = random.nextLong(usersize) + 1L;
+                executorService.execute(() -> {
+                    try {
+                        couponUseCase.issueCouponRequest(couponId, userId);
+                    } catch (Exception e) {
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+
+                log.info("couponId : " + couponId + " userId : " + userId);
+            }
+
+            countDownLatch.await();
+            executorService.shutdown();
+
+            // 스케쥴러 동작을 위한 슬립
+            Thread.sleep(10000);
+
+            // then
+            // 쿠폰 발급 확인 ( 맞지 않을 수 있음 ( 쿠폰2에 대해 발급 요청이 0건인 경우 ) )
+            List<UserCoupon> userCoupon = userCouponJPARepository.findAll();
+            assertEquals(200, userCoupon.size());
+
+            // 쿠폰 재고 학인
+            Long couponQuantity = redisService.getCouponQuantity(
+                COUPON_KEY + coupon.getCouponId().toString());
+            assertEquals(0, couponQuantity);
+
+            couponQuantity = redisService.getCouponQuantity(
+                COUPON_KEY + coupon2.getCouponId().toString());
+            assertEquals(0, couponQuantity);
+            // 쿠폰 발급 이력 1건인지 확인
+            Integer issuedList = redisService.getCouponIssuedList(COUPON_ISSUED_KEY);
+            assertEquals(200, redisService.getCouponIssuedList(COUPON_ISSUED_KEY));
         }
     }
 }

--- a/src/test/java/com/hhplush/eCommerce/integration/config/IntegrationTest.java
+++ b/src/test/java/com/hhplush/eCommerce/integration/config/IntegrationTest.java
@@ -26,6 +26,8 @@ import com.hhplush.eCommerce.infrastructure.product.IProductJPARepository;
 import com.hhplush.eCommerce.infrastructure.product.IProductQuantityJPARepository;
 import com.hhplush.eCommerce.infrastructure.product.IProductTopJPARepository;
 import com.hhplush.eCommerce.infrastructure.product.ProductRepository;
+import com.hhplush.eCommerce.infrastructure.redis.RedisRepository;
+import com.hhplush.eCommerce.infrastructure.redis.RedisService;
 import com.hhplush.eCommerce.infrastructure.user.IUserJPARepository;
 import com.hhplush.eCommerce.infrastructure.user.UserRepository;
 import io.restassured.RestAssured;
@@ -98,12 +100,17 @@ public class IntegrationTest {
     protected PaymentUseCase paymentUseCase;
     @Autowired
     protected PaymentService paymentService;
-
     @Autowired
     protected ObjectMapper objectMapper;
-
     @Autowired
     protected CustomLoggingFilter customLoggingFilter;
+
+    // 레디스
+    @Autowired
+    protected RedisService redisService;
+
+    @Autowired
+    protected RedisRepository redisRepository;
 
     protected String baseUrl = "http://localhost:";
     @LocalServerPort

--- a/src/test/java/com/hhplush/eCommerce/integration/config/IntegrationTest.java
+++ b/src/test/java/com/hhplush/eCommerce/integration/config/IntegrationTest.java
@@ -129,6 +129,7 @@ public class IntegrationTest {
         productQuantityJPARepository.deleteAll();
         productJPARepository.deleteAll();
         userJPARepository.deleteAll();
+        redisService.deleteAllKeys();
     }
 
 }


### PR DESCRIPTION
### **커밋 링크**
구성 파일 추가 : ac0d2ecf38cb19b1150480f204c97606d476aba1, 0440ad81098d9af28967d426ad4a84eac763e953
쿠폰 발급 기능 추가 V2 ( 발급 대기열, 대기열을 처리하는 스케줄러 ) : c455d7dfb4f2f596701954075aff6abdeb7120fe, 86227b53193b6b13102355cd53240048bca9283
쿠폰 발급을 위한 통합테스트 추가 : 8145ba830cfb92c6969cfcccc672979ab3f94436
오류 수정:  7ea3b47

---
### **리뷰 포인트(질문)**
- 쿠폰 발급 프로세스의 통합테스트 작성시 쿠폰을 2개 사용자를 200명으로 멀티 쓰레드를 이용하여 500회 시도하여 (랜덤으로) 쿠폰을 재고 소진하도록 유도하여 테스트를 진행하였습니다. 성공/실패에 대한 결과값은 순전히 운? 에 달렸는데 이런 캐이스들은 정합성검증을 어떻게하는게좋을까요? 
  - 저는 횟수를 늘려 재고를 모두 소진시키도록(최대한) 하였습니다. 진행하다보면 경우에 따라 오류가 발생할 수도 있을 것 같습니다.
- 레디스를 사용할 때 레디스 레포지토리를 생성 하였습니다. 레디스 서비스를 만들어서 해당하는 부분을 처리 해야 하나? 하다가 레디스 역시 레포지토리로 사용된다고 생각하여 레포지토리를 사용하였고 인프라 영역의 서비스는 레거시(테스트코드에서 사용...)?로 남겨 놓았는데 보통 어떤 방식으로 사용하실까요?

- 7ea3b47 커밋에 이슈가 있습니다.  테스트는 정상적으로 전부 동작하지만 테스트 컨테이너가 스프링보다 일찍종료함으로써 스케줄러에서 레디스 조회중에 오류가 발생하는 부분인데요 이부분에 대한 해결방법이나 조언을 구할수있을까요? 


```
 ./gradlew clean test
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-02-05 13:21:29 - MySQL 컨테이너 종료
2025-02-05 13:21:29 - Redis 컨테이너 종료
2025-02-05 13:21:29 - Closing JPA EntityManagerFactory for persistence unit 'default'
2025-02-05 13:21:29 - HangHaePlusDataSource - Shutdown initiated...
2025-02-05 13:21:29 - HangHaePlusDataSource - Shutdown completed.
2025-02-05 13:21:29 - Commencing graceful shutdown. Waiting for active requests to complete
2025-02-05 13:21:29 - Graceful shutdown complete
2025-02-05 13:21:34 - Unexpected error occurred in scheduled task
org.redisson.client.WriteRedisConnectionException: Unable to write command into connection! Check CPU usage of the JVM. Try to increase nettyThreads setting. Netty pending tasks: 0, Node source: NodeSource [slot=0, addr=null, redisClient=null, redirect=null, entry=null], connection: RedisConnection@709608738 [redisClient=[addr=redis://localhost:64712,localhost/127.0.0.1:64712], channel=[id: 0x175b8dd9, L:/127.0.0.1:64753 ! R:localhost/127.0.0.1:64712], currentCommand=null, usage=1], command: (EVAL), params: [local v = redis.call('zrange', KEYS[1], ARGV[1], ARGV[2]); if #v > 0 then redis.call('zremrangebyrank', KEYS[1], ARGV[1], ARGV[2]); return v; end return v;, 1, coupon:queue, 0, 9] after 3 retry attempts
        at org.redisson.command.RedisExecutor.checkWriteFuture(RedisExecutor.java:379)
        at org.redisson.command.RedisExecutor.lambda$execute$3(RedisExecutor.java:202)
        at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590)
        at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557)
        at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492)
        at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636)
        at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629)
        at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118)
        at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetFailure(AbstractChannel.java:997)
        at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:858)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1314)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:889)
        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:956)
        at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1263)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: io.netty.channel.StacklessClosedChannelException: null
        at io.netty.channel.AbstractChannel$AbstractUnsafe.write(Object, ChannelPromise)(Unknown Source)
2025-02-05 13:21:34 - Closing JPA EntityManagerFactory for persistence unit 'default'
2025-02-05 13:21:34 - HangHaePlusDataSource - Shutdown initiated...
2025-02-05 13:21:34 - HangHaePlusDataSource - Shutdown completed.

```
---
### **이번주 KPT 회고**

### Keep
- ...

### Problem
- 명절에 많이쉬면 안될 것 같습니다...
- 이번엔 하지못했지만 다음 과제 시작전에 코치님들의 피드백을 반영 하는것이 목표입니다.

### Try
- 다음엔 spy 객체를 이용하여 분산락 - 트랜잭션 우선순위에 대해 테스트 코드를 작성해보는것이 목표입니다. ( 이전 하헌우 코치님 피드백..)